### PR TITLE
日付ごとにグラフで表示できるようにした

### DIFF
--- a/routes/appointment.py
+++ b/routes/appointment.py
@@ -2,6 +2,16 @@ from flask import Blueprint, render_template, request, redirect, url_for
 from models.appointment import Appointment
 from models.user import User
 from datetime import datetime
+import io
+import base64
+import matplotlib
+matplotlib.use('Agg')  # バックエンドをAggに設定
+import matplotlib.pyplot as plt
+from collections import defaultdict
+import matplotlib.ticker as ticker
+
+# 日本語フォントを設定
+plt.rcParams['font.family'] = 'Hiragino Sans' 
 
 appointment_bp = Blueprint('appointment', __name__, url_prefix='/appointments')
 
@@ -15,7 +25,38 @@ def list():
     for appointment in appointments:
         if isinstance(appointment.appointment_datetime, str):
             appointment.appointment_datetime = datetime.strptime(appointment.appointment_datetime, '%Y-%m-%dT%H:%M')
-    return render_template('appointment_list.html', title='予約一覧', items=appointments)
+    
+    # 予約データを日付ごとに集計
+    date_counts = defaultdict(int)
+    for appointment in appointments:
+        date = appointment.appointment_datetime.date()
+        date_counts[date] += 1
+
+    # 日付でソート
+    sorted_dates = sorted(date_counts.keys())
+    counts = [date_counts[date] for date in sorted_dates]
+
+    # グラフの作成
+    plt.figure(figsize=(10, 5))
+    plt.plot(sorted_dates, counts, marker='o')
+    plt.title('日別予約数', color='black') 
+    plt.xlabel('日付', color='black')           
+    plt.ylabel('予約数', color='black')            
+    plt.grid(True)
+    plt.gca().yaxis.set_major_locator(ticker.MultipleLocator(1))
+    plt.tight_layout()
+
+    # グラフを画像としてバッファに保存
+    buf = io.BytesIO()
+    plt.savefig(buf, format='png')
+    buf.seek(0)
+    plt.close()
+
+    # 画像をBase64エンコード
+    image_base64 = base64.b64encode(buf.getvalue()).decode('utf-8')
+    buf.close()
+
+    return render_template('appointment_list.html', title='予約一覧', items=appointments, image_base64=image_base64)
 
 @appointment_bp.route('/add', methods=['GET', 'POST'])
 def add():

--- a/static/base-style.css
+++ b/static/base-style.css
@@ -13,7 +13,8 @@ table {
   margin-bottom: 2rem;
 }
 
-th, td {
+th,
+td {
   border: 1px solid #ddd;
   padding: 8px;
   text-align: left;
@@ -28,12 +29,15 @@ th {
   margin-bottom: 2rem;
   list-style: none;
 }
+
 .breadcrumb li {
   display: inline;
 }
+
 .breadcrumb li::after {
   content: " > ";
 }
+
 .breadcrumb li:nth-last-child()::after {
   content: "";
 }

--- a/templates/appointment_list.html
+++ b/templates/appointment_list.html
@@ -49,6 +49,10 @@
             {% endfor %}
         </tbody>
     </table>
+
+    <h2>日別予約数のグラフ</h2>
+    <img src="data:image/png;base64,{{ image_base64 }}" alt="日別予約数のグラフ">
+
 </body>
 
 </html>


### PR DESCRIPTION
# 変更内容

## routes/appointment.py

- **`list` 関数の修正**
  - 予約データを日付ごとに集計する処理を追加。
  - Matplotlibを使用して日別予約数の折れ線グラフを生成。
  - 生成したグラフをBase64エンコードし、テンプレートに渡す処理を追加。

## templates/appointment_list.html

- **グラフの埋め込み**
  - 予約一覧テーブルの下部に日別予約数のグラフを表示するための `<img>` タグを追加。
  
  ```html:templates/appointment_list.html
  <!-- グラフの埋め込み -->
  <h2>日別予約数のグラフ</h2>
  <img src="data:image/png;base64,{{ image_base64 }}" alt="日別予約数のグラフ">
  ```


## 備考

- データ量が多い場合は、表示範囲やフィルタリングを検討。
- グラフを埋め込んだ場所は現段階ではappointment_list.htmlだが後々完成したindex.htmlに移行させる